### PR TITLE
Hazelcast 4.2 added

### DIFF
--- a/models/cluster.go
+++ b/models/cluster.go
@@ -28,6 +28,7 @@ type StarterHazelcastVersion string
 const (
 	Version312 StarterHazelcastVersion = "VERSION_3_12"
 	Version40  StarterHazelcastVersion = "VERSION_4_0"
+	Version42  StarterHazelcastVersion = "VERSION_4_2"
 )
 
 //Zone topology type for enterprise Hazelcast Cloud clusters


### PR DESCRIPTION
Hazelcast 4.2 added since this is the latest version in cloud. Blocks https://github.com/hazelcast/hazelcast-cloud-cli/pull/29